### PR TITLE
Fixed button styling of input[type="submit"]

### DIFF
--- a/css/Aristo/jquery-ui-1.8.7.custom.css
+++ b/css/Aristo/jquery-ui-1.8.7.custom.css
@@ -494,14 +494,15 @@ button.ui-button-icons-only { width: 3.7em; }
 }
  
 /*button text element */
-.ui-button .ui-button-text { display: block; line-height: 1.4; font-size: 14px; font-weight: bold; text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6); }
+.ui-button .ui-button-text { display: block; line-height: 1.4; }
+.ui-button .ui-button-text, input.ui-button { font-size: 14px; font-weight: bold; text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6); }
 .ui-button-text-only .ui-button-text { padding: .4em 1em; }
 .ui-button-icon-only .ui-button-text, .ui-button-icons-only .ui-button-text { padding: .4em; text-indent: -9999999px; }
 .ui-button-text-icon-primary .ui-button-text, .ui-button-text-icons .ui-button-text { padding: .4em 1em .4em 2.1em; }
 .ui-button-text-icon-secondary .ui-button-text, .ui-button-text-icons .ui-button-text { padding: .4em 2.1em .4em 1em; }
 .ui-button-text-icons .ui-button-text { padding-left: 2.1em; padding-right: 2.1em; }
 /* no icon support for input elements, provide padding by default */
-input.ui-button { padding: .4em 1em; }
+input.ui-button { padding: .5em 1em; }
 
 /*button icon element(s) */
 .ui-button-icon-only .ui-icon, .ui-button-text-icon-primary .ui-icon, .ui-button-text-icon-secondary .ui-icon, .ui-button-text-icons .ui-icon, .ui-button-icons-only .ui-icon { position: absolute; top: 50%; margin-top: -8px; }

--- a/demo.html
+++ b/demo.html
@@ -70,7 +70,7 @@
 				);
 				
 				// Button
-				$("#divButton, #linkButton").button();
+				$("#divButton, #linkButton, #submitButton, #buttonElement").button();
 								
 				// Icon Buttons
 				$("#leftIconButton").button({
@@ -141,6 +141,8 @@
 		<h2 class="demoHeaders">UI Button</h2>	
 		<div id="divButton">&lt;DIV&gt; Button</div>
 		<a id="linkButton" href="#">&lt;A href="#"&gt; Button</a>
+		<input id="submitButton" type="submit" value="Submit Button">
+		<button id="buttonElement">Button Element</button>
 		
 		<!-- Icon Buttons -->
 		<h2 class="demoHeaders">Icon Buttons</h2>


### PR DESCRIPTION
It was too small, but I applied the styles of .ui-button-text to it and that brought it into line. Firefox won't let you set the line height on input elements, so had to use padding instead. Looks great on Firefox and Safari (didn't check IE).
