### PR TITLE
Really fixes issue #44 this time

### DIFF
--- a/css/Aristo/Aristo.css
+++ b/css/Aristo/Aristo.css
@@ -654,7 +654,7 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
 .ui-datepicker .ui-datepicker-buttonpane button { float: right; margin: .5em .2em .4em; cursor: pointer; padding: .2em .6em .3em .6em; width:auto; overflow:visible; }
 .ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current { float:left; }
 .ui-datepicker table .ui-state-highlight { border-color: #5F83B9; }
-.ui-datepicker table .ui-state-hover { background: #5F83B9; color: #FFF; font-weight: bold; text-shadow: 0 1px 1px #234386; }
+.ui-datepicker table .ui-state-hover { background: #5F83B9; color: #FFF; font-weight: bold; text-shadow: 0 1px 1px #234386; -webkit-box-shadow: 0 0px 0 rgba(255,255,255,0.6) inset; -moz-box-shadow: 0 0px 0 rgba(255,255,255,0.6) inset; box-shadow: 0 0px 0 rgba(255,255,255,0.6) inset; border-color: #5F83B9; }
 .ui-datepicker-calendar .ui-state-default { background: transparent; border-color: #FFF; }
 .ui-datepicker-calendar .ui-state-active { background: #5F83B9; border-color: #5F83B9; color: #FFF; font-weight: bold; text-shadow: 0 1px 1px #234386; }
 


### PR DESCRIPTION
The current date is displayed on the calendar with a 1px border of color 5F83B9.
If the selected date is different then the current date, and the user hovers over the current date, there is a 1px white line between the top of the hover background color and the current date border.
The cause of this is the box-shadow CSS3 property as it starts with a 1px line before it applies the box shadow.
This fix disables the box-shadow when the user hovers over a date.
In addition, when the user hovers over a date there is no border applied.  If the user hovers over a date next to the current date you can see the hover background is 1px smaller on all sides.  This is because the hover doesn't apply a border.
This fix applies the border to the date that the user hovers over.
