### PR TITLE
Input Tag Buttons Have Normal Font Weight When Inside Widgets

### DIFF
--- a/css/Aristo/Aristo.css
+++ b/css/Aristo/Aristo.css
@@ -495,7 +495,7 @@ button.ui-button-icons-only { width: 3.7em; }
 .ui-button-text-icon-secondary .ui-button-text, .ui-button-text-icons .ui-button-text { padding: .4em 2.1em .4em 1em; }
 .ui-button-text-icons .ui-button-text { padding-left: 2.1em; padding-right: 2.1em; }
 /* no icon support for input elements, provide padding by default */
-input.ui-button { font-size: 14px; font-weight: bold; text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6); padding: 0 1em !important; height: 33px; }
+input.ui-button, .ui-widget-content input.ui-button { font-size: 14px; font-weight: bold; text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6); padding: 0 1em !important; height: 33px; }
 /*remove submit button internal padding in Firefox*/ 
 input.ui-button::-moz-focus-inner { 
     border: 0;


### PR DESCRIPTION
Creating a UI button from an input element that is inside of a widget such as a tab pane or dialog will exhibit normal font weight on that element. This is due to a style applied to .ui-widget-content .ui-state-default on line 78. However, this is inconsistent with the behavior of UI buttons created from button or anchor elements.

This inconsistency can be resolved by modifying the selector on line 498 to:

input.ui-button, .ui-widget-content input.ui-button
