### PR TITLE
Add missing CSS3 box-shadow for firefox 13

### DIFF
--- a/css/Aristo/Aristo.css
+++ b/css/Aristo/Aristo.css
@@ -548,6 +548,7 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
 .ui-dialog {
 	-webkit-box-shadow: 0 2px 12px rgba(0,0,0,0.6);
 	-moz-box-shadow: 0 2px 12px rgba(0,0,0,0.6);
+	box-shadow: 0 2px 12px rgba(0,0,0,0.6);
 }
 .ui-dialog .ui-dialog-titlebar { padding: 0.7em 1em 0.6em 1em; position: relative; border: none; border-bottom: 1px solid #979797; -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;  }
 .ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .2em 0; font-size: 14px; text-shadow: 0 1px 0 rgba(255,255,255,0.5); } 


### PR DESCRIPTION
Firefox 13 no longer supports the -moz- prefix, which means everything has to have the standardized CSS3 properties. "box-shadow" was missing on ui-dialog. There may be others, but this was all I found so far.
